### PR TITLE
Downgrading “overriding old revision state” warning

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/MultiSCMRevisionState.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/MultiSCMRevisionState.java
@@ -48,7 +48,7 @@ final class MultiSCMRevisionState extends SCMRevisionState {
         String key = scm.getKey();
         SCMRevisionState old = revisionStates.put(key, scmState);
         if (old != null) {
-            Logger.getLogger(MultiSCMRevisionState.class.getName()).log(Level.WARNING, "overriding old revision state {0} from {1}", new Object[] {old, key});
+            Logger.getLogger(MultiSCMRevisionState.class.getName()).log(Level.FINE, "overriding old revision state {0} from {1}", new Object[] {old, key});
         }
 	}
 


### PR DESCRIPTION
Produced an irrelevant warning in harmless cases like a `Jenkinsfile` with

```groovy
node {
  checkout scm
}
```

where in fact the two `SCMRevisionState`s were the same. (Unfortunately this API does not force implementors to define `hashCode`/`equals` so we cannot tell if there is really a problem or not.)

@reviewbybees