### PR TITLE
Call buildEnvVars

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.workflow.steps.scm;
 
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.SCMListener;
@@ -123,7 +124,7 @@ public abstract class SCMStep extends AbstractStepImpl implements Serializable {
                 l.onCheckout(run, scm, workspace, listener, changelogFile, pollingBaseline);
             }
             scm.postCheckout(run, launcher, workspace, listener);
-            // TODO should we call buildEnvVars and return the result?
+            scm.buildEnvVars((AbstractBuild<?,?>) run, run.getEnvironment(listener));
     }
 
     public static abstract class SCMStepDescriptor extends AbstractStepDescriptorImpl {


### PR DESCRIPTION
I need `GIT_PREVIOUS_SUCCESSFUL_COMMIT` to be accessible from within my Jenkinsfile. After some digging I found the todo `// TODO should we call buildEnvVars and return the result?` and decided to get a conversation going by submitting this PR.

I don't know Jenkins internals at all, so my guess is that this is way off for what I actually need. I'm happy to work on this with someone to guide me.