### PR TITLE
Switching from ProcessBuilder to LocalLauncher

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/AbstractSampleRepoRule.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/AbstractSampleRepoRule.java
@@ -24,7 +24,10 @@
 
 package org.jenkinsci.plugins.workflow.steps.scm;
 
+import hudson.Launcher;
+import hudson.model.TaskListener;
 import hudson.triggers.SCMTrigger;
+import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.util.Arrays;
 import static org.hamcrest.Matchers.is;
@@ -38,13 +41,8 @@ public abstract class AbstractSampleRepoRule extends ExternalResource {
 
     public static void run(boolean probing, File cwd, String... cmds) throws Exception {
         try {
-            ProcessBuilder pb = new ProcessBuilder(cmds);
-            try {
-                ProcessBuilder.class.getMethod("inheritIO").invoke(pb);
-            } catch (NoSuchMethodException x) {
-                // TODO remove when Java 7+
-            }
-            int r = pb.directory(cwd).start().waitFor();
+            TaskListener listener = StreamTaskListener.fromStdout();
+            int r = new Launcher.LocalLauncher(listener).launch().cmds(cmds).pwd(cwd).stdout(listener).join();
             String message = Arrays.toString(cmds) + " failed with error code";
             if (probing) {
                 Assume.assumeThat(message, r, is(0));


### PR DESCRIPTION
`ProcessBuilder.inheritIO` had two problems:

* It printed text to `stdout`/`stderr` even when using `-Dmaven.test.redirectTestOutputToFile=true`, as for example in `mvn test`, producing a lot of noise. ([reference](https://github.com/jenkinsci/plugin-pom/blob/2d152753158fd2ec8eb92e97c0d2f161f64ee8b5/pom.xml#L955-L965))
* On Windows—but not Linux—it seems to cause every process execution to take ~10–40s (with CPU idle), ultimately causing the whole test case to time out.

@reviewbybees