### PR TITLE
[FIXED JENKINS-46597] Finally fix root cause by getting rid of TreeMap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <scm-api-plugin.version>2.2.0</scm-api-plugin.version>
         <git-plugin.version>3.6.0</git-plugin.version>
         <subversion-plugin.version>2.8</subversion-plugin.version>
-        <workflow-step-api-plugin.version>2.9</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
     </properties>
     <dependencies>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.29</version>
+            <version>2.41</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -33,9 +33,9 @@ import hudson.model.listeners.SCMListener;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -88,7 +88,7 @@ public abstract class SCMStep extends Step {
             StepContext ctx = getContext();
             Run<?, ?> run = ctx.get(Run.class);
             step.checkout(run, ctx.get(FilePath.class), ctx.get(TaskListener.class), ctx.get(Launcher.class));
-            Map<String,String> envVars = new TreeMap<>();
+            Map<String,String> envVars = new HashMap<>();
             step.createSCM().buildEnvironment(run, envVars);
             return envVars;
         }


### PR DESCRIPTION
[JENKINS-46597](https://issues.jenkins-ci.org/browse/JENKINS-46597)

TreeMap$Entry isn't serializable, so returning a TreeMap from
checkout(scm) opens up a bunch of possible problems. Switching to a
HashMap fixes that.

cc @reviewbybees 