### PR TITLE
[JENKINS-47201] Synchronize on Run when accessing MultiSCMRevisionState

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -110,9 +110,11 @@ public abstract class SCMStep extends Step {
             SCMRevisionState baseline = null;
             Run<?,?> prev = run.getPreviousBuild();
             if (prev != null) {
+                synchronized (prev) {
                 MultiSCMRevisionState state = prev.getAction(MultiSCMRevisionState.class);
                 if (state != null) {
                     baseline = state.get(scm);
+                }
                 }
             }
             scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
@@ -120,12 +122,14 @@ public abstract class SCMStep extends Step {
             if (poll || changelog) {
                 pollingBaseline = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);
                 if (pollingBaseline != null) {
+                    synchronized (run) {
                     MultiSCMRevisionState state = run.getAction(MultiSCMRevisionState.class);
                     if (state == null) {
                         state = new MultiSCMRevisionState();
                         run.addAction(state);
                     }
                     state.add(scm, pollingBaseline);
+                    }
                 }
             }
             for (SCMListener l : SCMListener.all()) {


### PR DESCRIPTION
See [JENKINS-47201](https://issues.jenkins-ci.org/browse/JENKINS-47201).

Similar to #21, but uses synchronization instead, which has the benefit of preventing a single job from having multiple MultiSCMRevisionState actions and avoids the issue of saving concurrent collections via XStream.

AIUI `run` here should always be an instance of `WorkflowRun`, which [synchronizes on itself before saving](https://github.com/jenkinsci/workflow-job-plugin/blob/fdc80e62ecd3d50ed58bc93b7d77c465e559e16f/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L1291), which should prevent the `ConcurrentModificationException`.

@reviewbybees 

CC @MartinNowak: If you are still interested in the issue and have a chance to test out this change, that would be very appreciated since I haven't been able to reproduce the issue in an automated test.