### PR TITLE
Fix polling only when polling is enabled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -111,24 +111,24 @@ public abstract class SCMStep extends Step {
             Run<?,?> prev = run.getPreviousBuild();
             if (prev != null) {
                 synchronized (prev) {
-                MultiSCMRevisionState state = prev.getAction(MultiSCMRevisionState.class);
-                if (state != null) {
-                    baseline = state.get(scm);
-                }
+                    MultiSCMRevisionState state = prev.getAction(MultiSCMRevisionState.class);
+                    if (state != null) {
+                        baseline = state.get(scm);
+                    }
                 }
             }
             scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
             SCMRevisionState pollingBaseline = null;
-            if (poll || changelog) {
+            if (poll) {
                 pollingBaseline = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);
                 if (pollingBaseline != null) {
                     synchronized (run) {
-                    MultiSCMRevisionState state = run.getAction(MultiSCMRevisionState.class);
-                    if (state == null) {
-                        state = new MultiSCMRevisionState();
-                        run.addAction(state);
-                    }
-                    state.add(scm, pollingBaseline);
+                        MultiSCMRevisionState state = run.getAction(MultiSCMRevisionState.class);
+                        if (state == null) {
+                            state = new MultiSCMRevisionState();
+                            run.addAction(state);
+                        }
+                        state.add(scm, pollingBaseline);
                     }
                 }
             }


### PR DESCRIPTION
From my point of view it does not make sense to have both `changelog` and `poll` as false to disable polling. From the tests i've made it seems to work as intended just by changing the condition. Please let me know of any restrictions or problems so that i might try to address them.