### PR TITLE
[JENKINS-34313] Prevent concurrent checkouts from using the same changelog file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -97,15 +97,6 @@ public abstract class SCMStep extends Step {
     }
 
     public final void checkout(Run<?,?> run, FilePath workspace, TaskListener listener, Launcher launcher) throws Exception {
-            File changelogFile = null;
-            if (changelog) {
-                for (int i = 0; ; i++) {
-                    changelogFile = new File(run.getRootDir(), "changelog" + i + ".xml");
-                    if (!changelogFile.exists()) {
-                        break;
-                    }
-                }
-            }
             SCM scm = createSCM();
             SCMRevisionState baseline = null;
             Run<?,?> prev = run.getPreviousBuild();
@@ -117,7 +108,18 @@ public abstract class SCMStep extends Step {
                 }
                 }
             }
-            scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
+            File changelogFile = null;
+            synchronized (run) {
+                if (changelog) {
+                    for (int i = 0; ; i++) {
+                        changelogFile = new File(run.getRootDir(), "changelog" + i + ".xml");
+                        if (!changelogFile.exists()) {
+                            break;
+                        }
+                    }
+                }
+                scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
+            }
             SCMRevisionState pollingBaseline = null;
             if (poll || changelog) {
                 pollingBaseline = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);


### PR DESCRIPTION
See [JENKINS-34313](https://issues.jenkins-ci.org/browse/JENKINS-34313).

Related to #27/[JENKINS-47201](https://issues.jenkins-ci.org/browse/JENKINS-47201). In that PR I was focusing too much on the `ConcurrentModificationException` for `MultiSCMRevisionState` and missed the concurrency issue with the changelog file. 

To fix it here, I moved the code around a bit so we can synchronize on `run` while checking for an available file name and creating it inside of `scm.checkout` without needing to synchronize on `prev` simultaneously.

Perhaps related to the issue that @tmcsantos was seeing when #31 was created?