### PR TITLE
Update plugin POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.48</version>
+        <version>3.50</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: SCM Step</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+SCM+Step+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+SCM+Step+Plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.21</version>
+        <version>3.48</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 3.21 to 3.48.

See [the changelog](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.21...plugin-3.48).