### PR TITLE
[JENKINS-59560] Delete empty changelog files to avoid issues in WorkflowRun.onCheckout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -122,6 +122,14 @@ public abstract class SCMStep extends Step {
                 }
             }
             scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
+            if (changelogFile != null && changelogFile.length() == 0) {
+                // JENKINS-57918/JENKINS-59560: Some SCM plugins don't write anything to the changelog file in some
+                // cases. `WorkflowRun.onCheckout` asks the SCM to parse the changelog file if it exists, and
+                // attempting to parse an empty file will cause an error, so we delete empty files before they even get
+                // to `WorkflowRun.onCheckout`.
+                Files.deleteIfExists(changelogFile.toPath());
+                changelogFile = null;
+            }
             SCMRevisionState pollingBaseline = null;
             if (poll || changelog) {
                 pollingBaseline = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);


### PR DESCRIPTION
See [JENKINS-57918](https://issues.jenkins-ci.org/browse/JENKINS-57918) and [JENKINS-59560](https://issues.jenkins-ci.org/browse/JENKINS-59560).

Tries to prevent issues where the SCM does not write anything to the changelog file, not even the headers for an empty XML file, so it doesn't cause problems later on in `WorkflowRun.onCheckout`.

I haven't had much luck trying to create automated tests in this plugin in the past, but we really need some to prevent regressions like this. We probably shouldn't merge this without any tests.