### PR TITLE
Check lastModified date of changelogFile in addition to its length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ work
 .classpath
 .project
 .settings
+
+# IntelliJ IDEA
+.idea
+*.iml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(useAci: true)

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -123,7 +123,8 @@ public abstract class SCMStep extends Step {
                 }
             }
             scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
-            if (changelogOriginalModifiedDate != null && changelogFile.lastModified() == changelogOriginalModifiedDate) {
+            if (changelogFile != null && changelogFile.length() == 0
+                    && changelogOriginalModifiedDate != null && changelogFile.lastModified() == changelogOriginalModifiedDate) {
                 // JENKINS-57918/JENKINS-59560/FakeChangeLogSCM: Some SCMs don't write anything to the changelog file in some
                 // cases. `WorkflowRun.onCheckout` asks the SCM to parse the changelog file if it exists, and
                 // attempting to parse an empty file will cause an error, so we delete changelog files that were not modified during the checkout before they even get

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -116,10 +116,10 @@ public abstract class SCMStep extends Step {
             Run<?,?> prev = run.getPreviousBuild();
             if (prev != null) {
                 synchronized (prev) {
-                    MultiSCMRevisionState state = prev.getAction(MultiSCMRevisionState.class);
-                    if (state != null) {
-                        baseline = state.get(scm);
-                    }
+                MultiSCMRevisionState state = prev.getAction(MultiSCMRevisionState.class);
+                if (state != null) {
+                    baseline = state.get(scm);
+                }
                 }
             }
             scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -123,9 +123,6 @@ public abstract class SCMStep extends Step {
                 }
             }
             scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
-            // If the changelog file has not been changed during the checkout, then we delete it.
-            // This applies to zero-byte files, which exist but are of 0 length, but were modified using a touch
-            // command, such as tests which use org.jvnet.hudson.test.FakeChangeLogSCM.checkout.
             if (changelogFile != null && changelogFile.lastModified() == changelogOriginalModifiedDate) {
                 // JENKINS-57918/JENKINS-59560: Some SCM plugins don't write anything to the changelog file in some
                 // cases. `WorkflowRun.onCheckout` asks the SCM to parse the changelog file if it exists, and

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -110,7 +110,7 @@ public abstract class SCMStep extends Step {
                     changelogFile = Files.createTempFile(run.getRootDir().toPath(), "changelog", ".xml").toFile();
                 }
             }
-            long changelogOriginalModifiedDate = (changelogFile != null) ? changelogFile.lastModified() : 1L;
+            Long changelogOriginalModifiedDate = (changelogFile != null) ? changelogFile.lastModified() : null;
             SCM scm = createSCM();
             SCMRevisionState baseline = null;
             Run<?,?> prev = run.getPreviousBuild();
@@ -123,7 +123,7 @@ public abstract class SCMStep extends Step {
                 }
             }
             scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
-            if (changelogFile != null && changelogFile.lastModified() == changelogOriginalModifiedDate) {
+            if (changelogOriginalModifiedDate != null && changelogFile.lastModified() == changelogOriginalModifiedDate) {
                 // JENKINS-57918/JENKINS-59560/FakeChangeLogSCM: Some SCMs don't write anything to the changelog file in some
                 // cases. `WorkflowRun.onCheckout` asks the SCM to parse the changelog file if it exists, and
                 // attempting to parse an empty file will cause an error, so we delete changelog files that were not modified during the checkout before they even get

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -126,7 +126,7 @@ public abstract class SCMStep extends Step {
             // If the changelog file has not been changed during the checkout, then we delete it.
             // This applies to zero-byte files, which exist but are of 0 length, but were modified using a touch
             // command, such as tests which use org.jvnet.hudson.test.FakeChangeLogSCM.checkout.
-            if (changelogFile.lastModified() == changelogOriginalModifiedDate) {
+            if (changelogFile != null && changelogFile.lastModified() == changelogOriginalModifiedDate) {
                 // JENKINS-57918/JENKINS-59560: Some SCM plugins don't write anything to the changelog file in some
                 // cases. `WorkflowRun.onCheckout` asks the SCM to parse the changelog file if it exists, and
                 // attempting to parse an empty file will cause an error, so we delete empty files before they even get

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -124,9 +124,9 @@ public abstract class SCMStep extends Step {
             }
             scm.checkout(run, launcher, workspace, listener, changelogFile, baseline);
             if (changelogFile != null && changelogFile.lastModified() == changelogOriginalModifiedDate) {
-                // JENKINS-57918/JENKINS-59560: Some SCM plugins don't write anything to the changelog file in some
+                // JENKINS-57918/JENKINS-59560/FakeChangeLogSCM: Some SCMs don't write anything to the changelog file in some
                 // cases. `WorkflowRun.onCheckout` asks the SCM to parse the changelog file if it exists, and
-                // attempting to parse an empty file will cause an error, so we delete empty files before they even get
+                // attempting to parse an empty file will cause an error, so we delete changelog files that were not modified during the checkout before they even get
                 // to `WorkflowRun.onCheckout`.
                 Files.deleteIfExists(changelogFile.toPath());
                 changelogFile = null;

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
@@ -40,6 +40,7 @@ import hudson.triggers.SCMTrigger;
 import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import jenkins.model.Jenkins;
@@ -188,7 +189,7 @@ public class SCMStepTest {
                     "  checkout(testSCM)\n" +
                     "}", false));
             WorkflowRun b = r.buildAndAssertSuccess(p);
-            assertThat(b.getCulpritIds().toString(), Matchers.containsString("alice1"));
+            assertThat(b.getCulpritIds(), Matchers.equalTo(Collections.singleton("alice1")));
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
@@ -165,7 +165,7 @@ public class SCMStepTest {
     }
 
     @Issue(value = { "JENKINS-57918", "JENKINS-59560" })
-    @Test public void scmParsesUmodifiedChangelogFile() {
+    @Test public void scmParsesUnmodifiedChangelogFile() {
         rr.then(r -> {
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
@@ -47,6 +47,7 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.impl.subversion.SubversionSampleRepoRule;
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -181,10 +182,13 @@ public class SCMStepTest {
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                     "import org.jvnet.hudson.test.FakeChangeLogSCM\n" +
+                    "def testSCM = new FakeChangeLogSCM()\n" +
+                    "testSCM.addChange().withAuthor(/alice$BUILD_NUMBER/)\n" +
                     "node() {\n" +
-                    "  checkout(new FakeChangeLogSCM())\n" +
+                    "  checkout(testSCM)\n" +
                     "}", false));
-            r.buildAndAssertSuccess(p);
+            WorkflowRun b = r.buildAndAssertSuccess(p);
+            assertThat(b.getCulpritIds().toString(), Matchers.containsString("alice1"));
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
@@ -194,7 +194,7 @@ public class SCMStepTest {
                 }
             };
         }
-        @TestExtension("scmParsesUmodifiedChangelogFile")
+        @TestExtension("scmParsesUnmodifiedChangelogFile")
         public static class DescriptorImpl extends NullSCM.DescriptorImpl { }
     }
 


### PR DESCRIPTION
# Summary
PCT runs could fail for the following two tests in workflow-job:

* [`CLITest.listChanges`](https://github.com/jenkinsci/workflow-job-plugin/blob/758059b19b127c09bdf1b07a9b77246634c1213d/src/test/java/org/jenkinsci/plugins/workflow/job/CLITest.java#L55-L62)
* [`WorkflowRunTest.culprits`](https://github.com/jenkinsci/workflow-job-plugin/blob/f61e0e7ee8bea00ac722f0fdb54f17bff150ebca/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java#L374-L426)

# Details

The reason for the failing test turned out to be [here](https://github.com/jenkinsci/workflow-scm-step-plugin/blob/d5c06f9ae5a587ec46a6623fe91bab02514c4946/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java#L125) in workflow-scm-step. Tests which make use of [`FakeChangeLogSCM` in the Jenkins Test Harness](https://github.com/jenkinsci/jenkins-test-harness/blob/0707c09b788bb782b20cd97bef7445900f380828/src/main/java/org/jvnet/hudson/test/FakeChangeLogSCM.java) were failing, because [this `touch`](https://github.com/jenkinsci/jenkins-test-harness/blob/0707c09b788bb782b20cd97bef7445900f380828/src/main/java/org/jvnet/hudson/test/FakeChangeLogSCM.java#L72) didn't behave correctly in the workflow-job test as a changed file. Now, we're looking to make sure the file exists, and instead of checking for zero length, we're checking for the file to be unmodified, via its `lastModified` date.

# Recreating the failure and the fix

This failure was not visible, because presently, `workflow-job` [specifies version 2.7](https://github.com/jenkinsci/workflow-job-plugin/blob/ded785da2ac68b9ecdd53dab426197fea28bd990/pom.xml#L129-L134) of `workflow-scm-step`. The failure can be recreated outside of the PCT, by setting workflow-job up to depend on workflow-scm-step 2.10.

Once that's complete, verify the fix by building this subject PR of workflow-scm-step via `mvn clean install`, and updating workflow-job to use workflow-scm-step 2.11-SNAPSHOT. The two failed tests will pass.

# Testing Performed

* Existing unit tests re-run
* Full build of workflow-job, using this snapshot as its dependency, passed 100%
* PCT run with this change bundled into the Jenkins under test