### PR TITLE
Update dependencies and split tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>4.16</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -40,25 +40,24 @@
     <properties>
         <revision>2.12</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.60</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
-        <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
-        <git-plugin.version>3.6.0</git-plugin.version>
-        <subversion-plugin.version>2.10.5</subversion-plugin.version>
-        <workflow-step-api-plugin.version>2.9</workflow-step-api-plugin.version>
-        <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
+        <subversion-plugin.version>2.14.0</subversion-plugin.version>
+        <svnkit.version>1.10.1</svnkit.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>credentials</artifactId>
-                <version>2.1.15</version>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.222.x</artifactId>
+                <version>23</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.tmatesoft.svnkit</groupId>
                 <artifactId>svnkit</artifactId>
-                <version>1.9.2</version>
+                <version>${svnkit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -66,69 +65,34 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>${scm-api-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>${scm-api-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>${git-plugin.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jenkins-ci</groupId>
-                    <artifactId>annotation-indexer</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                    <artifactId>workflow-scm-step</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>${git-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
-            <exclusions>
-                <exclusion> <!-- TODO IIRC this was a mistake in git-client which was since fixed -->
-                    <groupId>org.jenkins-ci</groupId>
-                    <artifactId>annotation-indexer</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                    <artifactId>workflow-scm-step</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
             <version>${subversion-plugin.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                    <artifactId>workflow-scm-step</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -136,109 +100,74 @@
             <version>${subversion-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                    <artifactId>workflow-scm-step</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.tmatesoft.svnkit</groupId>
             <artifactId>svnkit-cli</artifactId>
-            <version>1.9.2</version>
+            <version>${svnkit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.29</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                    <artifactId>workflow-scm-step</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.14</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                    <artifactId>workflow-scm-step</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>5.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow-support-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mercurial</artifactId>
-            <version>1.54</version>
+            <version>2.12</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion> <!-- git-client has a newer one -->
-                    <groupId>com.jcraft</groupId>
-                    <artifactId>jsch</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.222.x</artifactId>
-                <version>23</version>
+                <version>25</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitSCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitSCMStepTest.java
@@ -118,6 +118,8 @@ public class GitSCMStepTest {
                     String repo = sampleGitRepo.fileUrl();
                     URI repoURI = new URI(repo);
                     assertThat("Repo: " + repo, new File(repoURI), is(anExistingDirectory()));
+                    File gitDir = new File(new File(repoURI), ".git");
+                    assertThat("gitDir: " + repo + "/.git", gitDir, is(anExistingDirectory()));
                     WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
                     p.setDefinition(
                             new CpsFlowDefinition(

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitSCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitSCMStepTest.java
@@ -1,0 +1,138 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps.scm;
+
+import static org.junit.Assert.*;
+
+import hudson.model.Label;
+import hudson.scm.ChangeLogSet;
+import hudson.triggers.SCMTrigger;
+
+import jenkins.plugins.git.GitSampleRepoRule;
+
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+public class GitSCMStepTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+    @Rule public GitSampleRepoRule sampleGitRepo = new GitSampleRepoRule();
+
+    @Issue("JENKINS-26761")
+    @Test
+    public void checkoutsRestored() throws Exception {
+        rr.then(
+                r -> {
+                    sampleGitRepo.init();
+                    WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+                    p.addTrigger(new SCMTrigger(""));
+                    r.createOnlineSlave(Label.get("remote"));
+                    p.setDefinition(
+                            new CpsFlowDefinition(
+                                    "node('remote') {\n"
+                                            + "    ws {\n"
+                                            + "        git($/"
+                                            + sampleGitRepo
+                                            + "/$)\n"
+                                            + "    }\n"
+                                            + "}",
+                                    true));
+                    p.save();
+                    WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                    r.assertLogContains("Cloning the remote Git repository", b);
+                    FileUtils.copyFile(new File(b.getRootDir(), "build.xml"), System.out);
+                });
+        rr.then(
+                r -> {
+                    WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+                    r.createOnlineSlave(Label.get("remote"));
+                    sampleGitRepo.write("nextfile", "");
+                    sampleGitRepo.git("add", "nextfile");
+                    sampleGitRepo.git("commit", "--message=next");
+                    sampleGitRepo.notifyCommit(r);
+                    WorkflowRun b = p.getLastBuild();
+                    assertEquals(2, b.number);
+                    r.assertLogContains(
+                            "Cloning the remote Git repository", b); // new agent, new workspace
+                    List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
+                    assertEquals(1, changeSets.size());
+                    ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
+                    assertEquals(b, changeSet.getRun());
+                    assertEquals("git", changeSet.getKind());
+                    Iterator<? extends ChangeLogSet.Entry> iterator = changeSet.iterator();
+                    assertTrue(iterator.hasNext());
+                    ChangeLogSet.Entry entry = iterator.next();
+                    assertEquals("[nextfile]", entry.getAffectedPaths().toString());
+                    assertFalse(iterator.hasNext());
+                });
+    }
+
+    @Test
+    public void gitChangelogSmokes() {
+        rr.then(
+                r -> {
+                    sampleGitRepo
+                            .init(); // GitSampleRepoRule provides default user gits@mplereporule
+                    WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+                    p.setDefinition(
+                            new CpsFlowDefinition(
+                                    "node() {\n"
+                                            + "  checkout(scm: [\n"
+                                            + "    $class: 'GitSCM',\n"
+                                            + "    branches: [[name: '*/master']],\n"
+                                            + "    userRemoteConfigs: [[url: '"
+                                            + sampleGitRepo.fileUrl()
+                                            + "']]\n"
+                                            + "  ])\n"
+                                            + "}",
+                                    true));
+                    sampleGitRepo.write("foo", "bar");
+                    sampleGitRepo.git("add", "foo");
+                    sampleGitRepo.git("commit", "-m", "Initial commit");
+                    WorkflowRun b1 = r.buildAndAssertSuccess(p);
+                    assertThat(b1.getCulpritIds(), Matchers.equalTo(Collections.emptySet()));
+                    sampleGitRepo.write("foo", "bar1");
+                    sampleGitRepo.git("add", "foo");
+                    sampleGitRepo.git("commit", "-m", "Second commit");
+                    WorkflowRun b2 = r.buildAndAssertSuccess(p);
+                    assertThat(b2.getCulpritIds(), Matchers.equalTo(Collections.singleton("gits")));
+                });
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitSCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/GitSCMStepTest.java
@@ -24,7 +24,12 @@
 
 package org.jenkinsci.plugins.workflow.steps.scm;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.io.FileMatchers.anExistingDirectory;
 
 import hudson.model.Label;
 import hudson.scm.ChangeLogSet;
@@ -45,6 +50,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -108,8 +114,10 @@ public class GitSCMStepTest {
     public void gitChangelogSmokes() {
         rr.then(
                 r -> {
-                    sampleGitRepo
-                            .init(); // GitSampleRepoRule provides default user gits@mplereporule
+                    sampleGitRepo.init();
+                    String repo = sampleGitRepo.fileUrl();
+                    URI repoURI = new URI(repo);
+                    assertThat("Repo: " + repo, new File(repoURI), is(anExistingDirectory()));
                     WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
                     p.setDefinition(
                             new CpsFlowDefinition(
@@ -118,7 +126,7 @@ public class GitSCMStepTest {
                                             + "    $class: 'GitSCM',\n"
                                             + "    branches: [[name: '*/master']],\n"
                                             + "    userRemoteConfigs: [[url: '"
-                                            + sampleGitRepo.fileUrl()
+                                            + repo
                                             + "']]\n"
                                             + "  ])\n"
                                             + "}",

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
@@ -180,9 +180,6 @@ public class SCMStepTest {
 
     @Test public void scmParsesChangelogFileFromFakeChangeLogSCM() {
         rr.then(r -> {
-            // sampleGitRepo is not actually used in this test, but for reasons unclear to me, if you remove the call to
-            // init, checkoutsRestored and gitChangelogSmokes fail when you run the entire test suite.
-            sampleGitRepo.init();
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                     "import org.jvnet.hudson.test.FakeChangeLogSCM\n" +
@@ -198,6 +195,7 @@ public class SCMStepTest {
 
     @Test public void gitChangelogSmokes() {
         rr.then(r -> {
+            sampleGitRepo.init(); // GitSampleRepoRule provides default user gits@mplereporule
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                     "node() {\n" +
@@ -207,7 +205,6 @@ public class SCMStepTest {
                             "    userRemoteConfigs: [[url: '" + sampleGitRepo.fileUrl() + "']]\n" +
                             "  ])\n" +
                             "}", true));
-            sampleGitRepo.init(); // GitSampleRepoRule provides default user gits@mplereporule
             sampleGitRepo.write("foo", "bar");
             sampleGitRepo.git("add", "foo");
             sampleGitRepo.git("commit", "-m", "Initial commit");

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
@@ -180,6 +180,9 @@ public class SCMStepTest {
 
     @Test public void scmParsesChangelogFileFromFakeChangeLogSCM() {
         rr.then(r -> {
+            // sampleGitRepo is not actually used in this test, but for reasons unclear to me, if you remove the call to
+            // init, checkoutsRestored and gitChangelogSmokes fail when you run the entire test suite.
+            sampleGitRepo.init();
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                     "import org.jvnet.hudson.test.FakeChangeLogSCM\n" +

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
@@ -26,34 +26,22 @@ package org.jenkinsci.plugins.workflow.steps.scm;
 
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.Label;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.NullSCM;
-import hudson.scm.PollingResult;
 import hudson.scm.RepositoryBrowser;
 import hudson.scm.SCMRevisionState;
-import hudson.scm.SubversionSCM;
-import hudson.triggers.SCMTrigger;
-import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
 import jenkins.model.Jenkins;
 
-import jenkins.plugins.git.GitSampleRepoRule;
-import jenkins.scm.impl.subversion.SubversionSampleRepoRule;
-import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
@@ -69,102 +57,6 @@ public class SCMStepTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public RestartableJenkinsRule rr = new RestartableJenkinsRule();
-    @Rule public GitSampleRepoRule sampleGitRepo = new GitSampleRepoRule();
-    @Rule public SubversionSampleRepoRule sampleSvnRepo = new SubversionSampleRepoRule();
-
-    @Issue("JENKINS-26100")
-    @Test
-    public void scmVars() throws Exception {
-        rr.then(r -> {
-            sampleSvnRepo.init();
-            sampleSvnRepo.write("Jenkinsfile", "node('remote') {\n" +
-                "    def svnRev = checkout(scm).SVN_REVISION\n" +
-                "    echo \"SVN_REVISION is ${svnRev}\"\n" +
-                "}\n");
-            sampleSvnRepo.svnkit("add", sampleSvnRepo.wc() + "/Jenkinsfile");
-            sampleSvnRepo.svnkit("commit", "--message=+Jenkinsfile", sampleSvnRepo.wc());
-            long revision = sampleSvnRepo.revision();
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-            p.setDefinition(new CpsScmFlowDefinition(new SubversionSCM(sampleSvnRepo.trunkUrl()), "Jenkinsfile"));
-            r.createOnlineSlave(Label.get("remote"));
-            WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-            r.assertLogContains("SVN_REVISION is " + revision, b);
-        });
-    }
-
-    @Issue("JENKINS-26761")
-    @Test public void checkoutsRestored() throws Exception {
-        rr.then(r -> {
-            sampleGitRepo.init();
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-            p.addTrigger(new SCMTrigger(""));
-            r.createOnlineSlave(Label.get("remote"));
-            p.setDefinition(new CpsFlowDefinition(
-                "node('remote') {\n" +
-                "    ws {\n" +
-                "        git($/" + sampleGitRepo + "/$)\n" +
-                "    }\n" +
-                "}", true));
-            p.save();
-            WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-            r.assertLogContains("Cloning the remote Git repository", b);
-            FileUtils.copyFile(new File(b.getRootDir(), "build.xml"), System.out);
-        });
-        rr.then(r -> {
-            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
-            r.createOnlineSlave(Label.get("remote"));
-            sampleGitRepo.write("nextfile", "");
-            sampleGitRepo.git("add", "nextfile");
-            sampleGitRepo.git("commit", "--message=next");
-            sampleGitRepo.notifyCommit(r);
-            WorkflowRun b = p.getLastBuild();
-            assertEquals(2, b.number);
-            r.assertLogContains("Cloning the remote Git repository", b); // new slave, new workspace
-            List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
-            assertEquals(1, changeSets.size());
-            ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
-            assertEquals(b, changeSet.getRun());
-            assertEquals("git", changeSet.getKind());
-            Iterator<? extends ChangeLogSet.Entry> iterator = changeSet.iterator();
-            assertTrue(iterator.hasNext());
-            ChangeLogSet.Entry entry = iterator.next();
-            assertEquals("[nextfile]", entry.getAffectedPaths().toString());
-            assertFalse(iterator.hasNext());
-        });
-    }
-
-    @Issue("JENKINS-32214")
-    @Test public void pollDuringBuild() throws Exception {
-        rr.then(r -> {
-            sampleSvnRepo.init();
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-            p.setDefinition(new CpsFlowDefinition(
-                "semaphore 'before'\n" +
-                "node {svn '" + sampleSvnRepo.trunkUrl() + "'}\n" +
-                "semaphore 'after'", true));
-            assertPolling(p, PollingResult.Change.INCOMPARABLE);
-            WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-            SemaphoreStep.success("before/1", null);
-            SemaphoreStep.waitForStart("after/1", b1);
-            assertPolling(p, PollingResult.Change.NONE);
-            SemaphoreStep.success("after/1", null);
-            r.assertBuildStatusSuccess(r.waitForCompletion(b1));
-            sampleSvnRepo.write("file2", "");
-            sampleSvnRepo.svnkit("add", sampleSvnRepo.wc() + "/file2");
-            sampleSvnRepo.svnkit("commit", "--message=+file2", sampleSvnRepo.wc());
-            WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
-            SemaphoreStep.success("before/2", null);
-            SemaphoreStep.waitForStart("after/2", b2);
-            assertPolling(p, PollingResult.Change.NONE);
-            WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
-            SemaphoreStep.waitForStart("before/3", b3);
-            assertPolling(p, PollingResult.Change.NONE);
-            sampleSvnRepo.write("file3", "");
-            sampleSvnRepo.svnkit("add", sampleSvnRepo.wc() + "/file3");
-            sampleSvnRepo.svnkit("commit", "--message=+file3", sampleSvnRepo.wc());
-            assertPolling(p, PollingResult.Change.SIGNIFICANT);
-        });
-    }
 
     @Issue(value = { "JENKINS-57918", "JENKINS-59560" })
     @Test public void scmParsesUnmodifiedChangelogFile() {
@@ -191,35 +83,6 @@ public class SCMStepTest {
             WorkflowRun b = r.buildAndAssertSuccess(p);
             assertThat(b.getCulpritIds(), Matchers.equalTo(Collections.singleton("alice1")));
         });
-    }
-
-    @Test public void gitChangelogSmokes() {
-        rr.then(r -> {
-            sampleGitRepo.init(); // GitSampleRepoRule provides default user gits@mplereporule
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-            p.setDefinition(new CpsFlowDefinition(
-                    "node() {\n" +
-                            "  checkout(scm: [\n" +
-                            "    $class: 'GitSCM',\n" +
-                            "    branches: [[name: '*/master']],\n" +
-                            "    userRemoteConfigs: [[url: '" + sampleGitRepo.fileUrl() + "']]\n" +
-                            "  ])\n" +
-                            "}", true));
-            sampleGitRepo.write("foo", "bar");
-            sampleGitRepo.git("add", "foo");
-            sampleGitRepo.git("commit", "-m", "Initial commit");
-            WorkflowRun b1 = r.buildAndAssertSuccess(p);
-            assertThat(b1.getCulpritIds(), Matchers.equalTo(Collections.emptySet()));
-            sampleGitRepo.write("foo", "bar1");
-            sampleGitRepo.git("add", "foo");
-            sampleGitRepo.git("commit", "-m", "Second commit");
-            WorkflowRun b2 = r.buildAndAssertSuccess(p);
-            assertThat(b2.getCulpritIds(), Matchers.equalTo(Collections.singleton("gits")));
-        });
-    }
-
-    private static void assertPolling(WorkflowJob p, PollingResult.Change expectedChange) {
-        assertEquals(expectedChange, p.poll(StreamTaskListener.fromStdout()).change);
     }
 
     public static class InvalidChangelogSCM extends NullSCM {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SvnSCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SvnSCMStepTest.java
@@ -1,0 +1,121 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps.scm;
+
+import static org.junit.Assert.*;
+
+import hudson.model.Label;
+import hudson.scm.PollingResult;
+import hudson.scm.SubversionSCM;
+import hudson.util.StreamTaskListener;
+
+import jenkins.scm.impl.subversion.SubversionSampleRepoRule;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class SvnSCMStepTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+    @Rule public SubversionSampleRepoRule sampleSvnRepo = new SubversionSampleRepoRule();
+
+    @Issue("JENKINS-26100")
+    @Test
+    public void scmVars() throws Exception {
+        rr.then(
+                r -> {
+                    sampleSvnRepo.init();
+                    sampleSvnRepo.write(
+                            "Jenkinsfile",
+                            "node('remote') {\n"
+                                    + "    def svnRev = checkout(scm).SVN_REVISION\n"
+                                    + "    echo \"SVN_REVISION is ${svnRev}\"\n"
+                                    + "}\n");
+                    sampleSvnRepo.svnkit("add", sampleSvnRepo.wc() + "/Jenkinsfile");
+                    sampleSvnRepo.svnkit("commit", "--message=+Jenkinsfile", sampleSvnRepo.wc());
+                    long revision = sampleSvnRepo.revision();
+                    WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+                    p.setDefinition(
+                            new CpsScmFlowDefinition(
+                                    new SubversionSCM(sampleSvnRepo.trunkUrl()), "Jenkinsfile"));
+                    r.createOnlineSlave(Label.get("remote"));
+                    WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                    r.assertLogContains("SVN_REVISION is " + revision, b);
+                });
+    }
+
+    @Issue("JENKINS-32214")
+    @Test
+    public void pollDuringBuild() throws Exception {
+        rr.then(
+                r -> {
+                    sampleSvnRepo.init();
+                    WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+                    p.setDefinition(
+                            new CpsFlowDefinition(
+                                    "semaphore 'before'\n"
+                                            + "node {svn '"
+                                            + sampleSvnRepo.trunkUrl()
+                                            + "'}\n"
+                                            + "semaphore 'after'",
+                                    true));
+                    assertPolling(p, PollingResult.Change.INCOMPARABLE);
+                    WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+                    SemaphoreStep.success("before/1", null);
+                    SemaphoreStep.waitForStart("after/1", b1);
+                    assertPolling(p, PollingResult.Change.NONE);
+                    SemaphoreStep.success("after/1", null);
+                    r.assertBuildStatusSuccess(r.waitForCompletion(b1));
+                    sampleSvnRepo.write("file2", "");
+                    sampleSvnRepo.svnkit("add", sampleSvnRepo.wc() + "/file2");
+                    sampleSvnRepo.svnkit("commit", "--message=+file2", sampleSvnRepo.wc());
+                    WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+                    SemaphoreStep.success("before/2", null);
+                    SemaphoreStep.waitForStart("after/2", b2);
+                    assertPolling(p, PollingResult.Change.NONE);
+                    WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+                    SemaphoreStep.waitForStart("before/3", b3);
+                    assertPolling(p, PollingResult.Change.NONE);
+                    sampleSvnRepo.write("file3", "");
+                    sampleSvnRepo.svnkit("add", sampleSvnRepo.wc() + "/file3");
+                    sampleSvnRepo.svnkit("commit", "--message=+file3", sampleSvnRepo.wc());
+                    assertPolling(p, PollingResult.Change.SIGNIFICANT);
+                });
+    }
+
+    private static void assertPolling(WorkflowJob p, PollingResult.Change expectedChange) {
+        assertEquals(expectedChange, p.poll(StreamTaskListener.fromStdout()).change);
+    }
+}


### PR DESCRIPTION
## Update dependencies and split tests

- Update minimum required core version and dependencies
- Use 2.222.x bom version 25
- Initialize repo before reading its fileUrl
- Split SCMStepTest into 3 tests

The separation of SCMTest into a git test, a subversion test, and other tests has allowed the tests to pass consistently in my environment.  I've submitted this pull request to check the same behavior on ci.jenkins.io.

Derived from #44 with thanks to @dwnusbaum .  No issue for me if this pull request is discarded in favor of #44.