### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The `checkout` step may be used to run any other SCM plugin, provided that it ha
 It could also be used to run an SCM for which there is a special integration that lacks support for an exotic feature.
 The step takes an `scm` parameter which is a map containing at least a `$class` parameter giving the full or simple class name of the desired `SCM` implementation, and the standard `poll` and `changelog` parameters.
 
-It also takes any other parameters supported by the SCM plugin in its configuration form, using their internal names and values; use [_Snippet Generator_](https://jenkins.io/redirect/pipeline-snippet-generator)to get a detailed example for your SCM.
+It also takes any other parameters supported by the SCM plugin in its configuration form, using their internal names and values; use [_Snippet Generator_](https://jenkins.io/redirect/pipeline-snippet-generator) to get a detailed example for your SCM.
 Optional parameters can be omitted and will take their default values (to the extent supported by the SCM plugin).
 For example, to run Mercurial (1.51-beta-2 or higher):
 


### PR DESCRIPTION
Words need to be separated by white space...