### PR TITLE
Do not compute polling baseline when polling is disabled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -164,16 +164,28 @@ public abstract class SCMStep extends Step {
                 changelogFile = null;
             }
             SCMRevisionState pollingBaseline = null;
-            if (poll || changelog) {
+            if (poll) {
                 pollingBaseline = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);
                 if (pollingBaseline != null) {
                     synchronized (run) {
-                    MultiSCMRevisionState state = run.getAction(MultiSCMRevisionState.class);
-                    if (state == null) {
-                        state = new MultiSCMRevisionState();
-                        run.addAction(state);
+                        MultiSCMRevisionState state = run.getAction(MultiSCMRevisionState.class);
+                        if (state == null) {
+                            state = new MultiSCMRevisionState();
+                            run.addAction(state);
+                        }
+                        state.add(scm, pollingBaseline);
                     }
-                    state.add(scm, pollingBaseline);
+                }
+            } else if (changelog) {
+                SCMRevisionState changelogBaseline = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);
+                if (changelogBaseline != null) {
+                    synchronized (run) {
+                        MultiSCMRevisionState state = run.getAction(MultiSCMRevisionState.class);
+                        if (state == null) {
+                            state = new MultiSCMRevisionState();
+                            run.addAction(state);
+                        }
+                        state.add(scm, changelogBaseline);
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -163,32 +163,21 @@ public abstract class SCMStep extends Step {
                 Files.deleteIfExists(changelogFile.toPath());
                 changelogFile = null;
             }
-            SCMRevisionState pollingBaseline = null;
-            if (poll) {
-                pollingBaseline = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);
-                if (pollingBaseline != null) {
+            SCMRevisionState baselineAfterCheckout = null;
+            if (poll || changelog) {
+                baselineAfterCheckout = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);
+                if (baselineAfterCheckout != null) {
                     synchronized (run) {
                         MultiSCMRevisionState state = run.getAction(MultiSCMRevisionState.class);
                         if (state == null) {
                             state = new MultiSCMRevisionState();
                             run.addAction(state);
                         }
-                        state.add(scm, pollingBaseline);
-                    }
-                }
-            } else if (changelog) {
-                SCMRevisionState changelogBaseline = scm.calcRevisionsFromBuild(run, workspace, launcher, listener);
-                if (changelogBaseline != null) {
-                    synchronized (run) {
-                        MultiSCMRevisionState state = run.getAction(MultiSCMRevisionState.class);
-                        if (state == null) {
-                            state = new MultiSCMRevisionState();
-                            run.addAction(state);
-                        }
-                        state.add(scm, changelogBaseline);
+                        state.add(scm, baselineAfterCheckout);
                     }
                 }
             }
+            SCMRevisionState pollingBaseline = poll ? baselineAfterCheckout : null;
             for (SCMListener l : SCMListener.all()) {
                 try {
                     l.onCheckout(run, scm, workspace, listener, changelogFile, pollingBaseline);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStepTest.java
@@ -288,4 +288,26 @@ class SCMStepTest {
             assertEquals(Collections.singleton("alice1"), b.getCulpritIds());
         });
     }
+
+    @Test
+    void pollFalseWithChangelogDoesNotPoll() throws Throwable {
+        extension.then(r -> {
+            sampleGitRepo.init();
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                    "node() {\n" +
+                    "  checkout(scm: [$class: 'GitSCM', branches: [[name: '*/master']], userRemoteConfigs: [[url: $/" + sampleGitRepo + "/$]]], poll: false, changelog: true)\n" +
+                    "}", true));
+            sampleGitRepo.write("foo", "bar");
+            sampleGitRepo.git("add", "foo");
+            sampleGitRepo.git("commit", "-m", "Initial commit");
+            r.buildAndAssertSuccess(p);
+            sampleGitRepo.write("foo", "bar1");
+            sampleGitRepo.git("add", "foo");
+            sampleGitRepo.git("commit", "-m", "Second commit");
+            assertPolling(p, PollingResult.Change.NONE);
+            WorkflowRun b2 = r.buildAndAssertSuccess(p);
+            assertEquals(Collections.singleton("gits"), b2.getCulpritIds());
+        });
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/workflow-scm-step-plugin/issues/274

### What changed

When an SCM checkout uses `poll: false`—such as Pipeline Shared Library retrievers or an explicit `checkout(..., poll: false)` step—`SCMStep` previously checked `if (poll || changelog)` before computing `pollingBaseline` and passing it to `SCMListener.onCheckout(...)`.

`WorkflowRun.SCMCheckout` stores this `pollingBaseline`, and `WorkflowJob.poll()` checks whether the baseline is non-null. As a result, a checkout with `poll: false` could still register a polling baseline, causing Jenkins to poll the repository and trigger builds unexpectedly.

This PR:

* Computes and assigns `pollingBaseline` only when `poll` is `true`.
* When `poll` is `false` and `changelog` is `true`, computes `changelogBaseline` and records it in `MultiSCMRevisionState`. This preserves changelog generation between builds without registering a polling baseline for the checkout.
* Adds the regression test `pollFalseWithChangelogDoesNotPoll`, verifying that `poll: false` checkouts do not trigger polling builds while changelogs are still preserved.

### Testing done

* Added `pollFalseWithChangelogDoesNotPoll`, which verifies `assertPolling(p, PollingResult.Change.NONE)` after commits are made to a repository checked out with `poll: false, changelog: true`.
* Ran `mvn clean test` across the full `workflow-scm-step-plugin` test suite.
* All 17 tests passed.
